### PR TITLE
Add back support for dbus in emacs docker images

### DIFF
--- a/24.5/Dockerfile
+++ b/24.5/Dockerfile
@@ -9,6 +9,7 @@ run apt-get update && \
             curl \
             git \
             imagemagick \
+            libdbus-1-dev \
             libgif-dev \
             libgnutls-dev \
             libgtk2.0-dev \

--- a/25.1/Dockerfile
+++ b/25.1/Dockerfile
@@ -9,6 +9,7 @@ run apt-get update && \
             curl \
             git \
             imagemagick \
+            libdbus-1-dev \
             libgif-dev \
             libgnutls-dev \
             libgtk2.0-dev \

--- a/25.2/Dockerfile
+++ b/25.2/Dockerfile
@@ -9,6 +9,7 @@ run apt-get update && \
             curl \
             git \
             imagemagick \
+            libdbus-1-dev \
             libgif-dev \
             libgnutls-dev \
             libgtk2.0-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ run apt-get update && \
             curl \
             git \
             imagemagick \
+            libdbus-1-dev \
             libgif-dev \
             libgnutls-dev \
             libgtk2.0-dev \


### PR DESCRIPTION
Solving #1 broke dbus support, which is breaking some of my emacs package installs. This (tries to) fix this by adding back dbus support into docker-emacs. 

I can't actually test it due to https://github.com/moby/moby/issues/22801, so can you verify `dbus-runtime-version` is available after building with this patch?