### PR TITLE
[Fix #7] Add Emacs 26 to the build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   - GIT_BRANCH="emacs-25.1"       DOCKER_TAGS="25.1"
   - GIT_BRANCH="emacs-25.2"       DOCKER_TAGS="25.2"
   - GIT_BRANCH="emacs-25.3"       DOCKER_TAGS="25.3 25 latest"
+  - GIT_BRANCH="emacs-26.0.91"    DOCKER_TAGS="26.0"
   - GIT_BRANCH="master"           DOCKER_TAGS="master"
 
 before_install: source functions.sh

--- a/26.0/Dockerfile
+++ b/26.0/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:16.04
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y \
+            autoconf \
+            automake \
+            build-essential \
+            curl \
+            git \
+            imagemagick \
+            ispell \
+            libdbus-1-dev \
+            libgif-dev \
+            libgnutls-dev \
+            libgtk2.0-dev \
+            libjpeg-dev \
+            libmagick++-dev \
+            libncurses-dev \
+            libpng-dev \
+            libtiff-dev \
+            libx11-dev \
+            libxpm-dev \
+            texinfo
+
+# Build emacs
+ARG GIT_REPOSITORY="git://git.sv.gnu.org/emacs.git"
+ARG GIT_BRANCH
+RUN git clone --depth 1 --branch $GIT_BRANCH $GIT_REPOSITORY /tmp/emacs && \
+    cd /tmp/emacs && \
+    ./autogen.sh && \
+    ./configure && \
+    make -j 8 install && \
+    rm -rf /tmp/emacs
+
+WORKDIR /rootfs
+ENTRYPOINT ["emacs"]

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 - `25.1` [25.1/Dockerfile](https://github.com/silex/docker-emacs/blob/master/25.1/Dockerfile)
 - `25.2` [25.2/Dockerfile](https://github.com/silex/docker-emacs/blob/master/25.2/Dockerfile)
 - `25.3`, `25`, `latest` [25.3/Dockerfile](https://github.com/silex/docker-emacs/blob/master/25.3/Dockerfile)
+- `26.0` [26.0/Dockerfile](https://github.com/silex/docker-emacs/blob/master/26.0/Dockerfile)
 - `master` [master/Dockerfile](https://github.com/silex/docker-emacs/blob/master/master/Dockerfile)
 
 # Description


### PR DESCRIPTION
Applying only the "pretest" tag to these builds.

When Emacs 26.1 becomes an official release then I'd guess you want to call the build "26.1 26 latest", and this "pretest" label can move forward to some snapshot of 27.