### PR TITLE
[Fix #9] Push new docker images only when Emacs sources change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: generic
 
 services: docker
 
+cache:
+  directories:
+  - $HOME/emacs-src
+
 env:
   - GIT_BRANCH="emacs-23.4"       DOCKER_TAGS="23.4 23"
   - GIT_BRANCH="emacs-24.5"       DOCKER_TAGS="24.5 24"
@@ -12,6 +16,8 @@ env:
   - GIT_BRANCH="master"           DOCKER_TAGS="master"
 
 before_install: source functions.sh
+
+before_script: fetch
 
 script: build
 

--- a/dockerfiles/Dockerfile.ubuntu12.emacs23
+++ b/dockerfiles/Dockerfile.ubuntu12.emacs23
@@ -24,11 +24,10 @@ RUN apt-get update && \
             texinfo
 
 # Build emacs
-ARG GIT_REPOSITORY="git://git.sv.gnu.org/emacs.git"
 ARG GIT_BRANCH
+COPY $GIT_BRANCH /tmp/emacs/
 
-RUN git clone --depth 1 --branch $GIT_BRANCH $GIT_REPOSITORY /tmp/emacs && \
-    cd /tmp/emacs && \
+RUN cd /tmp/emacs && \
     ./configure --with-crt-dir=/usr/lib/x86_64-linux-gnu && \
     make bootstrap && \
     make -j 8 install && \

--- a/dockerfiles/Dockerfile.ubuntu16.emacs24+
+++ b/dockerfiles/Dockerfile.ubuntu16.emacs24+
@@ -24,11 +24,10 @@ RUN apt-get update && \
             texinfo
 
 # Build emacs
-ARG GIT_REPOSITORY="git://git.sv.gnu.org/emacs.git"
 ARG GIT_BRANCH
+COPY $GIT_BRANCH /tmp/emacs/
 
-RUN git clone --depth 1 --branch $GIT_BRANCH $GIT_REPOSITORY /tmp/emacs && \
-    cd /tmp/emacs && \
+RUN cd /tmp/emacs && \
     ./autogen.sh && \
     ./configure && \
     make -j 8 install && \

--- a/functions.sh
+++ b/functions.sh
@@ -1,19 +1,50 @@
 #!/usr/bin/env bash
 
-
 # Determine Dockerhub name by splitting the "repo slug",
-# i.e. if the GitHub repo is Silex/emacs then
-# DOCKER_REPO=silex
-
+# i.e. if the GitHub repo is Silex/emacs then DOCKER_REPO=silex
 DOCKER_REPO=$(echo $TRAVIS_REPO_SLUG | cut -d "/" -f 1 | tr '[:upper:]' '[:lower:]')
 DOCKER_IMG=emacs
+
+TRAVIS_CACHE=$HOME/emacs-src
+GIT_SRC_REPO=git://git.sv.gnu.org/emacs.git
+
+fetch()
+{
+  # Fetch and update sources from git. This works for branches
+  # ("master") as well as tagged releases ("emacs-25.3"). However
+  # checking out a tag leaves you in the 'detached HEAD' state such
+  # that further pulls don't do anything. This is fine because git
+  # doesn't permit tags to be moved.
+
+  [ ! -d $TRAVIS_CACHE ] &&  mkdir $TRAVIS_CACHE
+
+  if [ ! -d $TRAVIS_CACHE/$GIT_BRANCH ]; then
+    echo git clone --branch $GIT_BRANCH $GIT_SRC_REPO $TRAVIS_CACHE/$GIT_BRANCH
+    git clone --branch $GIT_BRANCH $GIT_SRC_REPO $TRAVIS_CACHE/$GIT_BRANCH
+  else
+    echo "cd $TRAVIS_CACHE/$GIT_BRANCH; git pull"
+    (cd $TRAVIS_CACHE/$GIT_BRANCH; git pull)
+  fi
+
+  # Copy updated sources to docker build context, and then remove
+  # the .git directory so it doesn't affect cache calculations
+  cp -pR $TRAVIS_CACHE/$GIT_BRANCH .
+  rm -rf ./$GIT_BRANCH/.git
+}
 
 build()
 {
   for tag in $DOCKER_TAGS; do
-    major=$(echo $tag | cut -d "." -f 1)  # i.e. "24.5" => "24"
-    echo Build $DOCKER_REPO/$DOCKER_IMG:$tag from source $GIT_BRANCH
+    echo Building $DOCKER_REPO/$DOCKER_IMG:$tag from source $GIT_BRANCH
+
+    # Select Dockerfile based on major number, i.e. "24.5" => "24"
+    major=$(echo $tag | cut -d "." -f 1)
+
+    # Pull previous image and use it as cache in the build.
+    # This is how docker knows if the sources have changed.
+    docker pull $DOCKER_REPO/$DOCKER_IMG:$tag
     docker build -t $DOCKER_REPO/$DOCKER_IMG:$tag \
+           --cache-from $DOCKER_REPO/$DOCKER_IMG:$tag \
            --build-arg="GIT_BRANCH=$GIT_BRANCH" \
            -f Dockerfile.$major .
   done


### PR DESCRIPTION
The main pieces are

1) tell Travis CI to cache `$HOME/emacs-src` so the contents are preserved between jobs
2) add a `fetch` function that runs git commands to maintain emacs sources in `$HOME/emacs-src`.
3) the `build` function passes the `--cache-from` flag
4) Dockerfiles now `COPY` the sources into the build
