### PR TITLE
[Fix #13] Make "slim" images (without compilers and dev libs)

### DIFF
--- a/dockerfiles/Dockerfile.ubuntu12.emacs23
+++ b/dockerfiles/Dockerfile.ubuntu12.emacs23
@@ -1,4 +1,4 @@
-FROM ubuntu:12.04
+FROM ubuntu:12.04 as full
 
 # Install dependencies
 RUN apt-get update && \
@@ -23,15 +23,44 @@ RUN apt-get update && \
             libxpm-dev \
             texinfo
 
+WORKDIR /rootfs
+ENV PATH="/opt/emacs/bin:${PATH}"
+CMD ["emacs"]
+
 # Build emacs
 ARG GIT_BRANCH
 COPY $GIT_BRANCH /tmp/emacs/
 
 RUN cd /tmp/emacs && \
-    ./configure --with-crt-dir=/usr/lib/x86_64-linux-gnu && \
+    ./configure --prefix=/opt/emacs \
+                --with-crt-dir=/usr/lib/x86_64-linux-gnu && \
     make bootstrap && \
     make -j 8 install && \
     rm -rf /tmp/emacs
 
+#--------------------------------------------------------------------------------
+FROM ubuntu:12.04
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y \
+            imagemagick \
+            ispell \
+            libgif4 \
+            libgnutls26 \
+            libgtk2.0-0 \
+            libjpeg8 \
+            libmagick++4 \
+            libncurses5 \
+            libpng12-0 \
+            libsm6 \
+            libtiff4 \
+            libx11-6 \
+            libxpm4 \
+            texinfo
+
 WORKDIR /rootfs
+ENV PATH="/opt/emacs/bin:${PATH}"
 CMD ["emacs"]
+
+COPY --from=full /opt/emacs /opt/emacs/

--- a/dockerfiles/Dockerfile.ubuntu16.emacs24+
+++ b/dockerfiles/Dockerfile.ubuntu16.emacs24+
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:16.04 as full
 
 # Install dependencies
 RUN apt-get update && \
@@ -24,19 +24,53 @@ RUN apt-get update && \
             python \
             texinfo
 
+WORKDIR /rootfs
+ENV PATH="/opt/emacs/bin:/root/.cask/bin:${PATH}"
+CMD ["emacs"]
+
+# Build emacs
 ARG GIT_BRANCH
 COPY $GIT_BRANCH /tmp/emacs/
 
-# Build Emacs
 RUN cd /tmp/emacs && \
     ./autogen.sh && \
-    ./configure && \
+    ./configure --prefix=/opt/emacs && \
     make -j 8 install && \
     rm -rf /tmp/emacs
 
 # Install Cask
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
-env PATH="/root/.cask/bin:${PATH}"
+
+#--------------------------------------------------------------------------------
+FROM ubuntu:16.04
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y \
+            curl \
+            git \
+            imagemagick \
+            ispell \
+            libgif7 \
+            libgnutls30 \
+            libgtk2.0-0 \
+            libjpeg8 \
+            libmagick++-6.q16-5v5 \
+            libncurses5 \
+            libpng12-0 \
+            libsm6 \
+            libtiff5 \
+            libx11-6 \
+            libxft2 \
+            libxpm4 \
+            python \
+            texinfo
 
 WORKDIR /rootfs
+ENV PATH="/opt/emacs/bin:/root/.cask/bin:${PATH}"
 CMD ["emacs"]
+
+COPY --from=full /opt/emacs /opt/emacs/
+
+# Install Cask
+RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python


### PR DESCRIPTION
With this change the Dockerfiles are now multi-stage builds.

The first ("full") build stage is as before: an Ubuntu install with compilers and development libraries as needed to compile emacs from source. However the Emacs makefile is now configured with `--prefix=/opt/emacs` so that the installation does not get intertwined with other packages in `/usr/local`.  PATH is also set accordingly.

The second ("slim") build stage has a modified Ubuntu install with no compilers, and just the runtime libraries rather than the development libraries. On average these "slim" builds are about 170MB smaller than their "full" counterparts.

The build process is a cascade, first "full" and then "slim".  Typically I'm seeing these builds take about 35 minutes per Emacs version, but only the first build where no caches exist. Subsequent builds are considerably faster.
