### PR TITLE
setup-env: Allow override of GITHUB_USER and DOCKER_REPOSITORY

### DIFF
--- a/bin/setup-env
+++ b/bin/setup-env
@@ -2,6 +2,6 @@
 
 export TRAVIS_CACHE="$HOME/cache"
 export GIT_REPOSITORY="git://git.sv.gnu.org/emacs.git"
-export GITHUB_USER="$(echo $TRAVIS_REPO_SLUG | cut -d '/' -f 1 | tr '[:upper:]' '[:lower:]')"
-export DOCKER_REPOSITORY="$GITHUB_USER/emacs"
+export GITHUB_USER="${GITHUB_USER:-$(echo ${TRAVIS_REPO_SLUG%%/*} | tr '[:upper:]' '[:lower:]')}"
+export DOCKER_REPOSITORY="${DOCKER_USERNAME:-${GITHUB_USER}}/emacs"
 export PATH="$(pwd)/bin:$PATH"


### PR DESCRIPTION
I've been using this for a while to build my own variants of the images and push them to my docker repository, which does not have the same name as my gihub account. 

It's sometimes useful to specify values for GITHUB_USER and
DOCKER_REPOSITORY that are not derived from TRAVIS_REPO_SLUG.  Two
examples are when not building with Travis or when the github user is
different from the Docker repository name.  DOCKER_USERNAME can be set
in the Travis settings just like the password.