### PR TITLE
Update ELPA key

### DIFF
--- a/23.4/ubuntu/12.04/bootstrap/Dockerfile
+++ b/23.4/ubuntu/12.04/bootstrap/Dockerfile
@@ -39,6 +39,10 @@ RUN cd /opt/emacs && \
     make && \
     make install
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -71,6 +75,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-23.4"
 ENV EMACS_VERSION="23.4"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.1/ubuntu/12.04/Dockerfile
+++ b/24.1/ubuntu/12.04/Dockerfile
@@ -42,6 +42,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -74,6 +78,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.1"
 ENV EMACS_VERSION="24.1"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.2/ubuntu/12.04/Dockerfile
+++ b/24.2/ubuntu/12.04/Dockerfile
@@ -42,6 +42,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -74,6 +78,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.2"
 ENV EMACS_VERSION="24.2"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.3/ubuntu/12.04/Dockerfile
+++ b/24.3/ubuntu/12.04/Dockerfile
@@ -42,6 +42,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -74,6 +78,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.3"
 ENV EMACS_VERSION="24.3"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.4/ubuntu/12.04/Dockerfile
+++ b/24.4/ubuntu/12.04/Dockerfile
@@ -42,6 +42,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -74,6 +78,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.4"
 ENV EMACS_VERSION="24.4"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.5/ubuntu/18.04/Dockerfile
+++ b/24.5/ubuntu/18.04/Dockerfile
@@ -55,6 +55,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -93,6 +97,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.5"
 ENV EMACS_VERSION="24.5"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.1/ubuntu/18.04/Dockerfile
+++ b/25.1/ubuntu/18.04/Dockerfile
@@ -55,6 +55,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -93,6 +97,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-25.1"
 ENV EMACS_VERSION="25.1"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.2/alpine/3.9/Dockerfile
+++ b/25.2/alpine/3.9/Dockerfile
@@ -51,6 +51,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -79,6 +83,7 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-25.2"
 ENV EMACS_VERSION="25.2"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.2/ubuntu/18.04/Dockerfile
+++ b/25.2/ubuntu/18.04/Dockerfile
@@ -55,6 +55,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -93,6 +97,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-25.2"
 ENV EMACS_VERSION="25.2"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.3/alpine/3.9/Dockerfile
+++ b/25.3/alpine/3.9/Dockerfile
@@ -51,6 +51,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -79,6 +83,7 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-25.3"
 ENV EMACS_VERSION="25.3"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.3/ubuntu/18.04/Dockerfile
+++ b/25.3/ubuntu/18.04/Dockerfile
@@ -55,6 +55,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -93,6 +97,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-25.3"
 ENV EMACS_VERSION="25.3"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.1/alpine/3.9/Dockerfile
+++ b/26.1/alpine/3.9/Dockerfile
@@ -51,6 +51,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -79,6 +83,7 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-26.1"
 ENV EMACS_VERSION="26.1"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.1/ubuntu/18.04/Dockerfile
+++ b/26.1/ubuntu/18.04/Dockerfile
@@ -55,6 +55,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -93,6 +97,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-26.1"
 ENV EMACS_VERSION="26.1"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.2/alpine/3.9/Dockerfile
+++ b/26.2/alpine/3.9/Dockerfile
@@ -51,6 +51,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -79,6 +83,7 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-26.2"
 ENV EMACS_VERSION="26.2"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.2/ubuntu/18.04/Dockerfile
+++ b/26.2/ubuntu/18.04/Dockerfile
@@ -55,6 +55,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -93,6 +97,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-26.2"
 ENV EMACS_VERSION="26.2"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.3/alpine/3.9/Dockerfile
+++ b/26.3/alpine/3.9/Dockerfile
@@ -51,6 +51,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -79,6 +83,7 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-26.3"
 ENV EMACS_VERSION="26.3"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.3/ubuntu/18.04/Dockerfile
+++ b/26.3/ubuntu/18.04/Dockerfile
@@ -55,6 +55,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -93,6 +97,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-26.3"
 ENV EMACS_VERSION="26.3"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/master/alpine/3.9/Dockerfile
+++ b/master/alpine/3.9/Dockerfile
@@ -51,6 +51,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -79,6 +83,7 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="master"
 ENV EMACS_VERSION="master"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/master/ubuntu/18.04/Dockerfile
+++ b/master/ubuntu/18.04/Dockerfile
@@ -55,6 +55,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -93,6 +97,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="master"
 ENV EMACS_VERSION="master"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/templates/alpine/3.9/Dockerfile
+++ b/templates/alpine/3.9/Dockerfile
@@ -51,6 +51,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -79,6 +83,7 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="{{BRANCH}}"
 ENV EMACS_VERSION="{{VERSION}}"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/templates/ubuntu/12.04/Dockerfile
+++ b/templates/ubuntu/12.04/Dockerfile
@@ -42,6 +42,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -74,6 +78,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="{{BRANCH}}"
 ENV EMACS_VERSION="{{VERSION}}"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/templates/ubuntu/12.04/bootstrap/Dockerfile
+++ b/templates/ubuntu/12.04/bootstrap/Dockerfile
@@ -39,6 +39,10 @@ RUN cd /opt/emacs && \
     make && \
     make install
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -71,6 +75,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="{{BRANCH}}"
 ENV EMACS_VERSION="{{VERSION}}"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/templates/ubuntu/18.04/Dockerfile
+++ b/templates/ubuntu/18.04/Dockerfile
@@ -55,6 +55,10 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
+RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
+    chmod 700 /root/.emacs.d/elpa/gnupg && \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
+
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -93,6 +97,7 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="{{BRANCH}}"
 ENV EMACS_VERSION="{{VERSION}}"
 
+COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]


### PR DESCRIPTION
The ELPA key was updated, and this broke all images below 26.3.

Additional informations in https://github.com/melpa/melpa/issues/6455 and https://github.com/clojure-emacs/cider/pull/2722