### PR TITLE
Improve ELPA key fix

### DIFF
--- a/23.4/ubuntu/12.04/bootstrap/Dockerfile
+++ b/23.4/ubuntu/12.04/bootstrap/Dockerfile
@@ -39,10 +39,6 @@ RUN cd /opt/emacs && \
     make && \
     make install
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -75,7 +71,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-23.4"
 ENV EMACS_VERSION="23.4"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.1/ubuntu/12.04/Dockerfile
+++ b/24.1/ubuntu/12.04/Dockerfile
@@ -42,10 +42,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -78,7 +74,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.1"
 ENV EMACS_VERSION="24.1"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.2/ubuntu/12.04/Dockerfile
+++ b/24.2/ubuntu/12.04/Dockerfile
@@ -42,10 +42,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -78,7 +74,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.2"
 ENV EMACS_VERSION="24.2"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.3/ubuntu/12.04/Dockerfile
+++ b/24.3/ubuntu/12.04/Dockerfile
@@ -42,10 +42,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -78,7 +74,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.3"
 ENV EMACS_VERSION="24.3"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.4/ubuntu/12.04/Dockerfile
+++ b/24.4/ubuntu/12.04/Dockerfile
@@ -42,10 +42,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -78,7 +74,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.4"
 ENV EMACS_VERSION="24.4"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/24.5/ubuntu/18.04/Dockerfile
+++ b/24.5/ubuntu/18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -97,7 +93,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-24.5"
 ENV EMACS_VERSION="24.5"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.1/ubuntu/18.04/Dockerfile
+++ b/25.1/ubuntu/18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -97,7 +93,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-25.1"
 ENV EMACS_VERSION="25.1"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.2/alpine/3.9/Dockerfile
+++ b/25.2/alpine/3.9/Dockerfile
@@ -51,10 +51,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -83,7 +79,6 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-25.2"
 ENV EMACS_VERSION="25.2"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.2/ubuntu/18.04/Dockerfile
+++ b/25.2/ubuntu/18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -97,7 +93,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-25.2"
 ENV EMACS_VERSION="25.2"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.3/alpine/3.9/Dockerfile
+++ b/25.3/alpine/3.9/Dockerfile
@@ -51,10 +51,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -83,7 +79,6 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-25.3"
 ENV EMACS_VERSION="25.3"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/25.3/ubuntu/18.04/Dockerfile
+++ b/25.3/ubuntu/18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -97,7 +93,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-25.3"
 ENV EMACS_VERSION="25.3"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.1/alpine/3.9/Dockerfile
+++ b/26.1/alpine/3.9/Dockerfile
@@ -51,10 +51,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -83,7 +79,6 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-26.1"
 ENV EMACS_VERSION="26.1"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.1/ubuntu/18.04/Dockerfile
+++ b/26.1/ubuntu/18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -97,7 +93,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-26.1"
 ENV EMACS_VERSION="26.1"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.2/alpine/3.9/Dockerfile
+++ b/26.2/alpine/3.9/Dockerfile
@@ -51,10 +51,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -83,7 +79,6 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-26.2"
 ENV EMACS_VERSION="26.2"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.2/ubuntu/18.04/Dockerfile
+++ b/26.2/ubuntu/18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -97,7 +93,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-26.2"
 ENV EMACS_VERSION="26.2"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.3/alpine/3.9/Dockerfile
+++ b/26.3/alpine/3.9/Dockerfile
@@ -51,10 +51,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -83,7 +79,6 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="emacs-26.3"
 ENV EMACS_VERSION="26.3"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/26.3/ubuntu/18.04/Dockerfile
+++ b/26.3/ubuntu/18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -97,7 +93,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="emacs-26.3"
 ENV EMACS_VERSION="26.3"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/master/alpine/3.9/Dockerfile
+++ b/master/alpine/3.9/Dockerfile
@@ -51,10 +51,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -83,7 +79,6 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="master"
 ENV EMACS_VERSION="master"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/master/ubuntu/18.04/Dockerfile
+++ b/master/ubuntu/18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -97,7 +93,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="master"
 ENV EMACS_VERSION="master"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/templates/alpine/3.9/Dockerfile
+++ b/templates/alpine/3.9/Dockerfile
@@ -51,10 +51,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -83,7 +79,6 @@ RUN apk add --no-cache \
 ENV EMACS_BRANCH="{{BRANCH}}"
 ENV EMACS_VERSION="{{VERSION}}"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/templates/ubuntu/12.04/Dockerfile
+++ b/templates/ubuntu/12.04/Dockerfile
@@ -42,10 +42,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -78,7 +74,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="{{BRANCH}}"
 ENV EMACS_VERSION="{{VERSION}}"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/templates/ubuntu/12.04/bootstrap/Dockerfile
+++ b/templates/ubuntu/12.04/bootstrap/Dockerfile
@@ -39,10 +39,6 @@ RUN cd /opt/emacs && \
     make && \
     make install
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -75,7 +71,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="{{BRANCH}}"
 ENV EMACS_VERSION="{{VERSION}}"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]

--- a/templates/ubuntu/18.04/Dockerfile
+++ b/templates/ubuntu/18.04/Dockerfile
@@ -55,10 +55,6 @@ RUN cd /opt/emacs && \
 ENV PATH="/root/.cask/bin:$PATH"
 RUN curl -fsSL https://raw.githubusercontent.com/cask/cask/master/go | python
 
-RUN mkdir -p /root/.emacs.d/elpa/gnupg && \
-    chmod 700 /root/.emacs.d/elpa/gnupg && \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --homedir /root/.emacs.d/elpa/gnupg --recv-keys 066DAFCB81E42C40
-
 CMD ["emacs"]
 
 # ------------------------------------------------------------
@@ -97,7 +93,6 @@ RUN apt-get update && \
 ENV EMACS_BRANCH="{{BRANCH}}"
 ENV EMACS_VERSION="{{VERSION}}"
 
-COPY --from=0 /root/.emacs.d /root/.emacs.d
 COPY --from=0 /usr/local /usr/local
 
 CMD ["emacs"]


### PR DESCRIPTION
@dickmao, @dpsutton @bbatsov: I updated the ELPA key in #52 (see https://github.com/Silex/docker-emacs/commit/038496343b786d19f6ee487642ba1aa5a507d10d), but I think what @purcell does at https://github.com/purcell/nix-emacs-ci/tree/master/patches is a better fix for the ELPA mess. Simply backport some patches so ELPA works again.

I'll thus revert the change and patch Emacs, which should make it so Emacs "just works" instead of having to handle the ELPA keys.

Feel free to comment about issues/ideas.