### PR TITLE
Change directory where keg is installed

### DIFF
--- a/24.5/debian/ci/keg/Dockerfile
+++ b/24.5/debian/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:24.5-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/25.3/alpine/ci/keg/Dockerfile
+++ b/25.3/alpine/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:25.3-alpine-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/25.3/debian/ci/keg/Dockerfile
+++ b/25.3/debian/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:25.3-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/26.3/alpine/ci/keg/Dockerfile
+++ b/26.3/alpine/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:26.3-alpine-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/26.3/debian/ci/keg/Dockerfile
+++ b/26.3/debian/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:26.3-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/27.2/alpine/ci/keg/Dockerfile
+++ b/27.2/alpine/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:27.2-alpine-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/27.2/debian/ci/keg/Dockerfile
+++ b/27.2/debian/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:27.2-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/28.1/alpine/ci/keg/Dockerfile
+++ b/28.1/alpine/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:28.1-alpine-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/28.1/debian/ci/keg/Dockerfile
+++ b/28.1/debian/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:28.1-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/28.2/alpine/ci/keg/Dockerfile
+++ b/28.2/alpine/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:28.2-alpine-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/28.2/debian/ci/keg/Dockerfile
+++ b/28.2/debian/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:28.2-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/master/alpine/ci/keg/Dockerfile
+++ b/master/alpine/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:master-alpine-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/master/debian/ci/keg/Dockerfile
+++ b/master/debian/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:master-ci
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/templates/alpine/ci/keg/Dockerfile
+++ b/templates/alpine/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:{{DEPENDS}}
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"

--- a/templates/debian/ci/keg/Dockerfile
+++ b/templates/debian/ci/keg/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:{{DEPENDS}}
 
-RUN git clone https://github.com/conao3/keg.el.git .keg
+RUN git clone https://github.com/conao3/keg.el.git /root/.keg
 ENV PATH="/root/.keg/bin:$PATH"


### PR DESCRIPTION
Thanks for your maintenance. 
In the `$version-ci-keg` image, `keg` is installed to `/.keg`, but `/root/.keg` is added to `PATH`.
So I fixed installation direction.

