### PR TITLE
Fix PATH for eldev

### DIFF
--- a/24.4/debian/ci/eldev/Dockerfile
+++ b/24.4/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:24.4-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/24.5/debian/ci/eldev/Dockerfile
+++ b/24.5/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:24.5-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/25.1/alpine/ci/eldev/Dockerfile
+++ b/25.1/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:25.1-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/25.1/debian/ci/eldev/Dockerfile
+++ b/25.1/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:25.1-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/25.2/alpine/ci/eldev/Dockerfile
+++ b/25.2/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:25.2-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/25.2/debian/ci/eldev/Dockerfile
+++ b/25.2/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:25.2-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/25.3/alpine/ci/eldev/Dockerfile
+++ b/25.3/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:25.3-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/25.3/debian/ci/eldev/Dockerfile
+++ b/25.3/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:25.3-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/26.1/alpine/ci/eldev/Dockerfile
+++ b/26.1/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:26.1-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/26.1/debian/ci/eldev/Dockerfile
+++ b/26.1/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:26.1-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/26.2/alpine/ci/eldev/Dockerfile
+++ b/26.2/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:26.2-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/26.2/debian/ci/eldev/Dockerfile
+++ b/26.2/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:26.2-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/26.3/alpine/ci/eldev/Dockerfile
+++ b/26.3/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:26.3-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/26.3/debian/ci/eldev/Dockerfile
+++ b/26.3/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:26.3-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/27.1/alpine/ci/eldev/Dockerfile
+++ b/27.1/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:27.1-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/27.1/debian/ci/eldev/Dockerfile
+++ b/27.1/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:27.1-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/27.2/alpine/ci/eldev/Dockerfile
+++ b/27.2/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:27.2-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/27.2/debian/ci/eldev/Dockerfile
+++ b/27.2/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:27.2-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/28.1/alpine/ci/eldev/Dockerfile
+++ b/28.1/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:28.1-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/28.1/debian/ci/eldev/Dockerfile
+++ b/28.1/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:28.1-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/28.2/alpine/ci/eldev/Dockerfile
+++ b/28.2/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:28.2-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/28.2/debian/ci/eldev/Dockerfile
+++ b/28.2/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:28.2-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/master/alpine/ci/eldev/Dockerfile
+++ b/master/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:master-alpine-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/master/debian/ci/eldev/Dockerfile
+++ b/master/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:master-ci
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/templates/alpine/ci/eldev/Dockerfile
+++ b/templates/alpine/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:{{DEPENDS}}
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"

--- a/templates/debian/ci/eldev/Dockerfile
+++ b/templates/debian/ci/eldev/Dockerfile
@@ -1,4 +1,4 @@
 FROM silex/emacs:{{DEPENDS}}
 
 RUN curl -fsSL https://raw.github.com/doublep/eldev/master/webinstall/eldev | sh
-ENV PATH="/root/.eldev/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"


### PR DESCRIPTION
The installation directory of eldev has changed.  See the links for details.

https://github.com/doublep/eldev/commit/fc4b71c3fde3a8829c041bd4f4bc209b766f25bb

https://github.com/doublep/eldev/issues/62