### PR TITLE
Fix typo that breaks cask URL on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,20 +10,20 @@ Wraps [nix-emacs-ci](https://github.com/purcell/nix-emacs-ci) in docker images.
 
 # Images
 
-| OS                                | Tag                      | Size (MB) | Inherits from      | Contents                                                              |
-|-----------------------------------|--------------------------|-----------|--------------------|-----------------------------------------------------------------------|
-| [debian](https://debian.org)      | $version                 | 370       |                    | Emacs & curl, gnupg, ssh, wget                                        |
-| [debian](https://debian.org)      | $version-ci              | 470       | $version           | [git](https://git-scm.com) & make                                     |
-| [debian](https://debian.org)      | $version-ci-cask         | 510       | $version-ci        | [Cask](https://caskreadthedocs.io) & [Python](https://www.python.org) |
-| [debian](https://debian.org)      | $version-ci-eask         | 510       | $version-ci        | [Eask](https://github.com/emacs-eask/cli)                             |
-| [debian](https://debian.org)      | $version-ci-eldev        | 470       | $version-ci        | [eldev](https://github.com/doublep/eldev)                             |
-| [debian](https://debian.org)      | $version-ci-keg          | 470       | $version-ci        | [keg](https://github.com/conao3/keg.el)                               |
-| [alpine](https://alpinelinux.org) | $version-alpine          | 240       |                    | Emacs & curl, gnupg, ssh, wget                                        |
-| [alpine](https://alpinelinux.org) | $version-alpine-ci       | 250       | $version-alpine    | [git](https://git-scm.com) & make                                     |
-| [alpine](https://alpinelinux.org) | $version-alpine-ci-cask  | 300       | $version-alpine-ci | [Cask](https://caskreadthedocs.io) & [Python](https://www.python.org) |
-| [alpine](https://alpinelinux.org) | $version-alpine-ci-eask  | 300       | $version-alpine-ci | [Eask](https://github.com/emacs-eask/cli)                             |
-| [alpine](https://alpinelinux.org) | $version-alpine-ci-eldev | 250       | $version-alpine-ci | [eldev](https://github.com/doublep/eldev)                             |
-| [alpine](https://alpinelinux.org) | $version-alpine-ci-keg   | 250       | $version-alpine-ci | [keg](https://github.com/conao3/keg.el)                               |
+| OS                                | Tag                      | Size (MB) | Inherits from      | Contents                                                               |
+|-----------------------------------|--------------------------|-----------|--------------------|------------------------------------------------------------------------|
+| [debian](https://debian.org)      | $version                 | 370       |                    | Emacs & curl, gnupg, ssh, wget                                         |
+| [debian](https://debian.org)      | $version-ci              | 470       | $version           | [git](https://git-scm.com) & make                                      |
+| [debian](https://debian.org)      | $version-ci-cask         | 510       | $version-ci        | [Cask](https://cask.readthedocs.io) & [Python](https://www.python.org) |
+| [debian](https://debian.org)      | $version-ci-eask         | 510       | $version-ci        | [Eask](https://github.com/emacs-eask/cli)                              |
+| [debian](https://debian.org)      | $version-ci-eldev        | 470       | $version-ci        | [eldev](https://github.com/doublep/eldev)                              |
+| [debian](https://debian.org)      | $version-ci-keg          | 470       | $version-ci        | [keg](https://github.com/conao3/keg.el)                                |
+| [alpine](https://alpinelinux.org) | $version-alpine          | 240       |                    | Emacs & curl, gnupg, ssh, wget                                         |
+| [alpine](https://alpinelinux.org) | $version-alpine-ci       | 250       | $version-alpine    | [git](https://git-scm.com) & make                                      |
+| [alpine](https://alpinelinux.org) | $version-alpine-ci-cask  | 300       | $version-alpine-ci | [Cask](https://cask.readthedocs.io) & [Python](https://www.python.org) |
+| [alpine](https://alpinelinux.org) | $version-alpine-ci-eask  | 300       | $version-alpine-ci | [Eask](https://github.com/emacs-eask/cli)                              |
+| [alpine](https://alpinelinux.org) | $version-alpine-ci-eldev | 250       | $version-alpine-ci | [eldev](https://github.com/doublep/eldev)                              |
+| [alpine](https://alpinelinux.org) | $version-alpine-ci-keg   | 250       | $version-alpine-ci | [keg](https://github.com/conao3/keg.el)                                |
 
 # Tags
 


### PR DESCRIPTION
Hey @Silex,
this PR fixes a small typo (a `.` missing) that broke the cask URL.
I've also realigned the table after adding that `.`; we're not barbarians here :wink:
Thanks!