### PR TITLE
Update Alpine images to Alpine 3.21

### DIFF
--- a/dockerfiles/alpine/Dockerfile
+++ b/dockerfiles/alpine/Dockerfile
@@ -11,7 +11,7 @@ RUN cd /nix-emacs/nix/store && ln -s *emacs* emacs
 
 # -------------------------------------------------------------------------------
 
-FROM alpine:3.14 AS base
+FROM alpine:3.21 AS base
 
 RUN apk add --no-cache \
             curl \


### PR DESCRIPTION
- v3.14 hasn't been supported since 2023-05-01

---

I ran into an issue with a package not being available and discovered that the Alpine base version was pretty old.